### PR TITLE
test(api): add integration tests for POST /api/perks (Fixes #21)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,18 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
+
 
     <build>
         <plugins>


### PR DESCRIPTION
Adds integration coverage for POST /api/perks using MockMvc.

- Verifies 201 created and JSON echo of saved entity
- Ensures server-side defaulting of upvotes/downvotes to 0
- Uses ObjectMapper with JSR-310 for LocalDate

Fixes #21 