### PR TITLE
feat(api): implement POST /api/perks (Fixes #19)

### DIFF
--- a/src/main/java/ca/carleton/s4806/perkmanager/controller/PerkController.java
+++ b/src/main/java/ca/carleton/s4806/perkmanager/controller/PerkController.java
@@ -3,10 +3,12 @@ package ca.carleton.s4806.perkmanager.controller;
 import ca.carleton.s4806.perkmanager.model.Perk;
 import ca.carleton.s4806.perkmanager.repository.PerkRepository;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;  // <-- add PostMapping, RequestBody, ResponseStatus
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;


### PR DESCRIPTION
Summary

Implements POST /api/perks in PerkController.
Creates a new Perk, defaults null vote counters to 0, persists via PerkRepository, and returns the saved entity.

Only file changed:
src/main/java/ca/carleton/s4806/perkmanager/controller/PerkController.java

Details

Add @PostMapping handler under /api/perks

Return 201 Created via @ResponseStatus(HttpStatus.CREATED)

Server-side defaults:

upvotes: 0 if null

downvotes: 0 if null

CORS remains enabled for frontend calls

Example request
POST /api/perks
Content-Type: application/json

{
  "title": "Student Discount",
  "description": "15% off general admission",
  "product": "Movies",
  "membership": "University",
  "location": "Ottawa, ON",
  "expiryDate": "2026-12-31"
}

Example response

201 Created with JSON body including generated id and vote counters 0.