### PR TITLE
Updated perk repo

### DIFF
--- a/src/main/java/ca/carleton/s4806/perkmanager/repository/PerkRepository.java
+++ b/src/main/java/ca/carleton/s4806/perkmanager/repository/PerkRepository.java
@@ -24,18 +24,18 @@ import java.util.List;
  */
 @Repository
 public interface PerkRepository extends JpaRepository<Perk, Long> {
-    List<Perk> findByTitleContainingIgnoreCase(String titleKeyword);
+        List<Perk> findByTitleContainingIgnoreCase(String titleKeyword);
 
-    List<Perk> findByProductContainingIgnoreCase(String productKeyword);
+        List<Perk> findByProductContainingIgnoreCase(String productKeyword);
 
-    List<Perk> findByTitleContainingIgnoreCaseOrProductContainingIgnoreCase(
-            String titleKeyword,
-            String productKeyword
-    );
+        List<Perk> findByTitleContainingIgnoreCaseOrProductContainingIgnoreCase(
+                        String titleKeyword,
+                        String productKeyword);
 
-    List<Perk> findByTitleContainingIgnoreCaseOrProductContainingIgnoreCase(
-            String titleKeyword,
-            String productKeyword,
-            Sort sort
-    );
+        List<Perk> findByTitleContainingIgnoreCaseOrProductContainingIgnoreCase(
+                        String titleKeyword,
+                        String productKeyword,
+                        Sort sort);
+
+        List<Perk> findByMembershipIn(List<ca.carleton.s4806.perkmanager.model.Membership> memberships);
 }


### PR DESCRIPTION
Updated PerkRepository to support filtering by memberships.
Added GET /api/perks/recommended to PerkController.
The logic fetches the logged-in user, gets their memberships, and returns matching perks.
If no user is logged in, it returns an empty list.